### PR TITLE
Implement profile cards handling

### DIFF
--- a/Dota2/GC/Callbacks.cs
+++ b/Dota2/GC/Callbacks.cs
@@ -680,5 +680,21 @@ namespace Dota2.GC
                 popup = up;
             }
         }
+
+        /// <summary>
+        ///     Response to a RequestProfileCards call
+        /// </summary>
+        public sealed class ProfileCardResponse : CallbackMsg
+        {
+            /// <summary>
+            /// The profile card response
+            /// </summary>
+            public CMsgDOTAProfileCard result;
+
+            internal ProfileCardResponse(CMsgDOTAProfileCard msg)
+            {
+                result = msg;
+            }
+        }
     }
 }

--- a/Dota2/GC/DotaGCHandler.cs
+++ b/Dota2/GC/DotaGCHandler.cs
@@ -763,6 +763,16 @@ namespace Dota2.GC
         }
 
         /// <summary>
+        ///     Requests someone's profile cards
+        /// </summary>
+        public void RequestProfileCards(uint account_id)
+        {
+            var request = new ClientGCMsgProtobuf<CMsgClientToGCGetProfileCard>((uint)EDOTAGCMsg.k_EMsgClientToGCGetProfileCard);
+            request.Body.account_id = account_id;
+            Send(request);
+        }
+
+        /// <summary>
         /// Packet GC message.
         /// </summary>
         /// <param name="eMsg"></param>
@@ -820,6 +830,7 @@ namespace Dota2.GC
                         {(uint) EDOTAGCMsg.k_EMsgGCGuildInviteAccountResponse, HandleGuildInviteAccountResponse},
                         {(uint) EDOTAGCMsg.k_EMsgGCGuildCancelInviteResponse, HandleGuildCancelInviteResponse},
                         {(uint) EDOTAGCMsg.k_EMsgGCGuildData, HandleGuildData},
+                        {(uint) EDOTAGCMsg.k_EMsgClientToGCGetProfileCardResponse, HandleProfileCardResponse },
                     };
                     Action<IPacketGCMsg> func;
                     if (!messageMap.TryGetValue(gcmsg.MsgType, out func))
@@ -1249,6 +1260,12 @@ namespace Dota2.GC
         {
             var resp = new ClientGCMsgProtobuf<CMsgDOTAGuildSDO>(obj);
             Client.PostCallback(new GuildDataResponse(resp.Body));
+        }
+
+        private void HandleProfileCardResponse(IPacketGCMsg obj)
+        {
+            var resp = new ClientGCMsgProtobuf<CMsgDOTAProfileCard>(obj);
+            Client.PostCallback(new ProfileCardResponse(resp.Body));
         }
     }
 }


### PR DESCRIPTION
Profile cards are those new editable profile fields where you can chose to display trophies/heroes/items/statistics.

This pull request introduces a new call

```
 RequestProfileCards(uint account_id);
```

as well as a callback for the associated response from the GC

```
 ProfileCardResponse
```
