### PR TITLE
Implement Rich Presence handling

### DIFF
--- a/Dota2/GC/Callbacks.cs
+++ b/Dota2/GC/Callbacks.cs
@@ -699,5 +699,21 @@ namespace Dota2.GC
                 result = msg;
             }
         }
+        
+        /// <summary>
+        ///     Called upon a rich presence update
+        /// </summary>
+        public sealed class RichPresenceUpdate : CallbackMsg
+        {
+            /// <summary>
+            /// The rich presence info 
+            /// </summary>
+            public CMsgClientRichPresenceInfo result;
+
+            internal RichPresenceUpdate(CMsgClientRichPresenceInfo msg)
+            {
+                result = msg;
+            }
+        }
     }
 }

--- a/Dota2/GC/DotaGCHandler.cs
+++ b/Dota2/GC/DotaGCHandler.cs
@@ -830,7 +830,7 @@ namespace Dota2.GC
                         {(uint) EDOTAGCMsg.k_EMsgGCGuildInviteAccountResponse, HandleGuildInviteAccountResponse},
                         {(uint) EDOTAGCMsg.k_EMsgGCGuildCancelInviteResponse, HandleGuildCancelInviteResponse},
                         {(uint) EDOTAGCMsg.k_EMsgGCGuildData, HandleGuildData},
-                        {(uint) EDOTAGCMsg.k_EMsgClientToGCGetProfileCardResponse, HandleProfileCardResponse },
+                        {(uint) EDOTAGCMsg.k_EMsgClientToGCGetProfileCardResponse, HandleProfileCardResponse},
                     };
                     Action<IPacketGCMsg> func;
                     if (!messageMap.TryGetValue(gcmsg.MsgType, out func))
@@ -863,6 +863,12 @@ namespace Dota2.GC
                         {
                             var msg = new ClientMsg<MsgClientOGSBeginSessionResponse>(packetMsg);
                             Client.PostCallback(new BeginSessionResponse(msg.Body));
+                        }
+                            break;
+                        case EMsg.ClientRichPresenceInfo:
+                        {
+                            var msg = new ClientMsgProtobuf<CMsgClientRichPresenceInfo>(packetMsg);
+                            Client.PostCallback(new RichPresenceUpdate(msg.Body));
                         }
                             break;
                     }


### PR DESCRIPTION
This fixes #10 by introducing a RichPresenceUpdate callback.

I've avoided parsing the KeyValue inside the callback for performance reasons, since there's no point in parsing rich presence information when not required by the user. This has the downside that the callback will trigger on all RP updates including other games e.g. Team Fortress 2. 

Example Usage for printing out all RP updates:

``` csharp
    Action<KeyValue, int> kvDeepPrint = null;

    // Recursively print a KeyValue structure
    kvDeepPrint = ((kv, depth) =>
    {
        Console.Write(new String('\t', depth));
        Console.ForegroundColor = ConsoleColor.Cyan;
        Console.Write(kv.Name);
        Console.Write("\t");
        Console.ResetColor();
        Console.WriteLine(kv.Value);

        foreach (var child in kv.Children)
            kvDeepPrint(child, depth + 1);
    });

    manager.Subscribe<DotaGCHandler.RichPresenceUpdate>(c =>
    {
        foreach (var richPresence in c.result.rich_presence)
        {
            using (MemoryStream stream = new MemoryStream(richPresence.rich_presence_kv))
            {
                KeyValue rp = new KeyValue();
                if (!rp.TryReadAsBinary(stream))
                    continue;

                Console.WriteLine("Rich Presence for " + richPresence.steamid_user);
                kvDeepPrint(rp, 0);
            }
        }
    });
```
